### PR TITLE
Fix markdown in related_projects.md

### DIFF
--- a/related_projects.md
+++ b/related_projects.md
@@ -1,3 +1,3 @@
-#Related Projects
+# Related Projects
 
   * [Code of Merit](https://github.com/rosarior/Code-of-Merit)


### PR DESCRIPTION
GitHub recently disallowed atx headings without a space following the pound.